### PR TITLE
Package.json updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "Takeoff",
-  "version": "2.0.1",
+  "version": "1.4.1",
   "main": "Gruntfile.js",
   "dependencies": {
     "grunt": "~0.4.5"
+  "scripts": {
+   "build": "grunt"
   },
   "devDependencies": {
     "autoprefixer": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,6 @@
   "name": "Takeoff",
   "version": "1.4.1",
   "main": "Gruntfile.js",
-  "dependencies": {
-    "grunt": "~0.4.5"
   "scripts": {
    "build": "grunt"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,7 +1705,7 @@ grunt-webfont@^0.5.3:
     underscore.string "~2.4.0"
     winston "~0.8.3"
 
-grunt@~0.4.5:
+grunt@^0.4.5, grunt@~0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/grunt/-/grunt-0.4.5.tgz#56937cd5194324adff6d207631832a9d6ba4e7f0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,7 +2362,11 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@~4.16.4:
+lodash@^4.0.0, lodash@~4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.5.1.tgz#80e8a074ca5f3893a6b1c10b2a636492d710c316"
+
+lodash@^4.14.0, lodash@~4.16.4:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
@@ -2381,10 +2385,6 @@ lodash@~1.0.1:
 lodash@~2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
-
-lodash@~4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.5.1.tgz#80e8a074ca5f3893a6b1c10b2a636492d710c316"
 
 log-symbols@^1.0.0:
   version "1.0.2"
@@ -3067,9 +3067,9 @@ qs@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.1.tgz#ce03c5ff0935bc1d9d69a9f14cbd18e568d67625"
 
-"qs@>= 0.4.0", qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+"qs@>= 0.4.0", qs@~6.3.0:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
 
 qs@~0.5.2:
   version "0.5.6"
@@ -3079,9 +3079,9 @@ qs@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-5.2.1.tgz#801fee030e0b9450d6385adc48a4cc55b44aedfc"
 
-qs@~6.3.0:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 randomatic@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
- changed the version to the one corresponding in the changelog file
- removed grunt as a dependency (it already was a dev dependency, which was throwing warnings when running grunt)
- added a script to package.json so we can use yarn/npm to run our build ('yarn run build').